### PR TITLE
Add "Mac" to the whitelist platforms

### DIFF
--- a/Plugins/ConsoleEnhanced/ConsoleEnhanced.uplugin
+++ b/Plugins/ConsoleEnhanced/ConsoleEnhanced.uplugin
@@ -19,7 +19,7 @@
 		{
 			"Name": "ConsoleEnhanced",
 			"Type": "Developer",
-			"WhitelistPlatforms": [ "Win64", "Win32" ],
+			"WhitelistPlatforms": [ "Win64", "Win32", "Mac" ],
 			"LoadingPhase": "Default"
 		}
 	]


### PR DESCRIPTION
Hi,

I've been using your Plugin for quite some time and every time a mac user wants to install it it's not appearing in the Menu, I just realized it's only because of that :)