### PR TITLE
Fix packaging error

### DIFF
--- a/Plugins/ConsoleEnhanced/Source/ConsoleEnhanced/ConsoleEnhanced.Build.cs
+++ b/Plugins/ConsoleEnhanced/Source/ConsoleEnhanced/ConsoleEnhanced.Build.cs
@@ -10,13 +10,17 @@ public class ConsoleEnhanced : ModuleRules
         bFasterWithoutUnity = true;
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
+        if (Target.Type == TargetType.Editor)
+        {
+            PrivateDependencyModuleNames.Add("UnrealEd");
+        }
+
         PrivateDependencyModuleNames.AddRange(
             new string[] {
                 "Core",
                 "CoreUObject",
                 "Engine",
                 "InputCore",
-                "UnrealEd",
                 "Slate",
                 "SlateCore",
                 "EditorStyle",


### PR DESCRIPTION
A lot of users were receiving this error whilst packaging their project:

```
UATHelper: Packaging (Windows (64-bit)):   ERROR: Unable to instantiate module 'UnrealEd': Unable to instantiate UnrealEd module for non-editor targets.
UATHelper: Packaging (Windows (64-bit)):   (referenced via Target -> ConsoleEnhanced.Build.cs)
```

UnrealEd is an editor module so it can't be included in packaged builds. Wrapping it in an if statement should fix the issue that many are experiencing :)