### PR TITLE
Add Linux whitelisting and fix incorrectly encoded regex pattern.

### DIFF
--- a/Plugins/ConsoleEnhanced/ConsoleEnhanced.uplugin
+++ b/Plugins/ConsoleEnhanced/ConsoleEnhanced.uplugin
@@ -19,7 +19,7 @@
 		{
 			"Name": "ConsoleEnhanced",
 			"Type": "Editor",
-			"WhitelistPlatforms": [ "Win64", "Win32", "Mac" ],
+			"WhitelistPlatforms": [ "Linux", "Win64", "Win32", "Mac" ],
 			"LoadingPhase": "Default"
 		}
 	]

--- a/Plugins/ConsoleEnhanced/Source/ConsoleEnhanced/Private/SOutputLog.cpp
+++ b/Plugins/ConsoleEnhanced/Source/ConsoleEnhanced/Private/SOutputLog.cpp
@@ -1047,7 +1047,7 @@ FOutputLogTextLayoutMarshaller::FOutputLogTextLayoutMarshaller(TArray< TSharedPt
     : Messages(MoveTemp(InMessages))
     , Filter(InFilter)
     , TextLayout(nullptr)
-    , UrlPattern(FRegexPattern(FString("\\b(((https?://)?www\\d{0,3}[.]|(https?://))([^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\"., <>?«»“”‘’]))")))
+    , UrlPattern(FRegexPattern(FString("\\b(((https?://)?www\\d{0,3}[.]|(https?://))([^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\"., <>?\xAB\xBB\x93\x94\x91\x92]))")))
 #if PLATFORM_MAC || PLATFORM_LINUX
     , FilePathPattern(FRegexPattern(FString("\"((?:/[^/]*)+)/?\"|((?:/[^/ \\n]*)+/?)")))
 #else


### PR DESCRIPTION
The plugin does work in Linux aside from a crash that occurs sometimes. I'd like to add preliminary support for Linux.

I'd also like to point out the regex pattern used in the FOutputLogTextLayoutMarshaller function contains incorrectly encoded bytes. Properly encoded bytes in C/C++ begin with \nnn (octal) or \xnn (hex). I've added this into the patch.